### PR TITLE
FIX undefined _id

### DIFF
--- a/elasticsearch/elasticsearch-search.js
+++ b/elasticsearch/elasticsearch-search.js
@@ -80,7 +80,8 @@ module.exports = function (RED) {
                   return;
                 } else {
                   for (var i in resp.hits.hits) {
-                    var obj = resp.hits.hits[i]._source;
+                    var obj = {};
+                    obj._source = resp.hits.hits[i]._source;
                     obj._id = resp.hits.hits[i]._id;
                     msg.payload.push(obj);
                     if (msg.payload.length % searchConfig.bulkSize == 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-red-contrib-elasticsearch-jupalcf",
-	"version": "1.1.24",
+	"version": "1.1.25",
 	"description": "elasticsearch Wrapper for NodeRed",
 	"main": "elasticsearch-index.js",
 	"node-red": {


### PR DESCRIPTION
When _source have value & is not object or dont exist, overwrite obj and _id get undefined.